### PR TITLE
refactor: ChecklistAgentの呼び出しを簡略化

### DIFF
--- a/src/mastra/workflows/recruit-workflow.ts
+++ b/src/mastra/workflows/recruit-workflow.ts
@@ -23,10 +23,7 @@ const checklistStep = createStep({
     requirementsList: z.string(),
   }),
   execute: async ({ inputData, mastra }) => {
-    const result = await ChecklistAgent.generate(inputData.userRequirements, {
-      threadId: workflowSessionIds.threadId,
-      resourceId: workflowSessionIds.resourceId,
-    });
+    const result = await ChecklistAgent.generate(inputData.userRequirements);
     const logger = mastra.getLogger();
     logger.info('チェックリスト生成結果:', result.text);
     logger.debug('セッションID:', workflowSessionIds);


### PR DESCRIPTION
## 概要
ChecklistAgentの呼び出しからセッションIDパラメータを削除してシンプルにした

## 変更内容
- `ChecklistAgent.generate()`の呼び出しから`threadId`と`resourceId`のパラメータを削除
- エージェントの呼び出しをより簡潔にリファクタリング

## 影響
- ChecklistAgentの使用がシンプルになり、コードの可読性が向上
- セッション管理が不要になり、保守性が改善

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>